### PR TITLE
Only upload specific files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "src/init.lua",
   "types": "src/index.d.ts",
-  "files": ["src/", "LICENSE", "CHANGELOG.md", "README.md"],
+  "files": ["src"],
   "scripts": {
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "main": "src/init.lua",
   "types": "src/index.d.ts",
+  "files": ["src/", "LICENSE", "CHANGELOG.md", "README.md"],
   "scripts": {
   },
   "repository": {


### PR DESCRIPTION
So files like `tsconfig.json` don't get uploaded, which can cause issues with things such as rojo 6.0