### PR TITLE
Improve Expectation["equal"] typings

### DIFF
--- a/src/Expectation.d.ts
+++ b/src/Expectation.d.ts
@@ -20,7 +20,7 @@ interface Expectation<T> {
 
 	// LINGUISTIC OPS
 	/** Applies a never operation to the expectation */
-	readonly never: InverseExpectation<T> & CustomMatchers;
+	readonly never: Expectation<unknown> & CustomMatchers;
 
 	// METHODS
 
@@ -66,42 +66,6 @@ interface Expectation<T> {
 	 * @returns If the assertion passes, returns reference to itself
 	 */
 	throw: (this: Expectation<Callback>, search?: string) => Expectation<T>;
-}
-
-type PartialExpectation<T> = Omit<Expectation<T>, keyof InverseExpectation<T>>;
-
-interface InverseExpectation<T> {
-	// LINGUISTIC NO-OPS
-	/** A linguistic no-op */
-	readonly to: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
-
-	/** A linguistic no-op */
-	readonly be: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
-
-	/** A linguistic no-op */
-	readonly been: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
-
-	/** A linguistic no-op */
-	readonly have: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
-
-	/** A linguistic no-op */
-	readonly was: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
-
-	/** A linguistic no-op */
-	readonly at: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
-
-	// LINGUISTIC OPS
-	/** Applies a never operation to the expectation */
-	readonly never: Expectation<T> & CustomMatchers;
-
-	// METHODS
-
-	/**
-	 * Assert that our expectation value is equal to another value
-	 * @param otherValue The other value
-	 * @returns If the assertion passes, returns reference to itself
-	 */
-	equal: (otherValue: unknown) => Expectation<T>;
 }
 
 interface ExpectationConstructor {

--- a/src/Expectation.d.ts
+++ b/src/Expectation.d.ts
@@ -68,25 +68,27 @@ interface Expectation<T> {
 	throw: (this: Expectation<Callback>, search?: string) => Expectation<T>;
 }
 
+type PartialExpectation<T> = Omit<Expectation<T>, keyof InverseExpectation<T>>;
+
 interface InverseExpectation<T> {
 	// LINGUISTIC NO-OPS
 	/** A linguistic no-op */
-	readonly to: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+	readonly to: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
 
 	/** A linguistic no-op */
-	readonly be: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+	readonly be: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
 
 	/** A linguistic no-op */
-	readonly been: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+	readonly been: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
 
 	/** A linguistic no-op */
-	readonly have: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+	readonly have: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
 
 	/** A linguistic no-op */
-	readonly was: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+	readonly was: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
 
 	/** A linguistic no-op */
-	readonly at: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+	readonly at: InverseExpectation<T> & PartialExpectation<T> & CustomMatchers;
 
 	// LINGUISTIC OPS
 	/** Applies a never operation to the expectation */

--- a/src/Expectation.d.ts
+++ b/src/Expectation.d.ts
@@ -20,7 +20,7 @@ interface Expectation<T> {
 
 	// LINGUISTIC OPS
 	/** Applies a never operation to the expectation */
-	readonly never: Expectation<T> & CustomMatchers;
+	readonly never: InverseExpectation<T> & CustomMatchers;
 
 	// METHODS
 
@@ -49,7 +49,7 @@ interface Expectation<T> {
 	 * @param otherValue The other value
 	 * @returns If the assertion passes, returns reference to itself
 	 */
-	equal: (otherValue: unknown) => Expectation<T>;
+	equal: (otherValue: T) => Expectation<T>;
 
 	/**
 	 * Assert that our expectation value is equal to another value within some
@@ -66,6 +66,40 @@ interface Expectation<T> {
 	 * @returns If the assertion passes, returns reference to itself
 	 */
 	throw: (this: Expectation<Callback>, search?: string) => Expectation<T>;
+}
+
+interface InverseExpectation<T> {
+	// LINGUISTIC NO-OPS
+	/** A linguistic no-op */
+	readonly to: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+
+	/** A linguistic no-op */
+	readonly be: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+
+	/** A linguistic no-op */
+	readonly been: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+
+	/** A linguistic no-op */
+	readonly have: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+
+	/** A linguistic no-op */
+	readonly was: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+
+	/** A linguistic no-op */
+	readonly at: InverseExpectation<T> & Expectation<T> & CustomMatchers;
+
+	// LINGUISTIC OPS
+	/** Applies a never operation to the expectation */
+	readonly never: Expectation<T> & CustomMatchers;
+
+	// METHODS
+
+	/**
+	 * Assert that our expectation value is equal to another value
+	 * @param otherValue The other value
+	 * @returns If the assertion passes, returns reference to itself
+	 */
+	equal: (otherValue: unknown) => Expectation<T>;
 }
 
 interface ExpectationConstructor {


### PR DESCRIPTION
equal takes in `unknown` to allow for "negative" equals:
```ts
expect(1).never.to.equal(undefined)
```
but this means there is no strong typing for "positive" equals:
```ts
// stringUnion: "foo" | "bar"
expect(stringUnion).to.equal("abcde") // is allowed when it shouldn't be
// also no autocomplete when writing inside equal(...)
```

This MR fixes that:
```ts
// stringUnion: "foo" | "bar"
expect(stringUnion).to.equal("abcde") // type error
expect(stringUnion).to.equal("foo") // allowed
expect(stringUnion).never.to.equal("abcde") // allowed

expect(1).never.to.equal(undefined) // allowed
expect(1).never.never.to.equal(undefined) // type error
expect(1).never.never.to.equal(1) // allowed
```
