### PR TITLE
Compile `expect.extend` as a callback

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -64,7 +64,7 @@ declare global {
 		/**
 		 * Adds a custom matcher
 		 */
-		extend(matchers: Partial<CustomMatchers>): void;
+		extend: (matchers: Partial<CustomMatchers>) => void;
 	};
 
 	/**


### PR DESCRIPTION
TestEz uses a metatable on a new object to wrap its `ExpectationContext`, so that `extend` is a callback. 
 https://github.com/Roblox/testez/blob/26a5247631279154c74425b94583c189b8447d0f/src/TestRunner.lua#L19

Pre-commit code will result in the following error when ran:

```
ReplicatedStorage.rbxts_include.node_modules.@rbxts.testez.src.ExpectationContext:32: Cannot overwrite matcher "extend"; it already exists
ReplicatedStorage.rbxts_include.node_modules.@rbxts.testez.src.ExpectationContext:32 function extend
ReplicatedStorage.rbxts_include.node_modules.@rbxts.testez.src.TestRunner:22 function extend
```